### PR TITLE
docs: make runtime tree portable across GitHub viewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Starting with v4.0.2, runtime state is stored outside the repository under:
 
 ```text
 %LOCALAPPDATA%\WindowsPrinterSharingFix\
-â”œâ”€â”€ backups\
-â”œâ”€â”€ logs\
-â””â”€â”€ language.cfg
+|-- backups\
+|-- logs\
+|-- language.cfg
 ```
 
 This keeps a Git clone clean when you change language or run diagnostics. Existing v4 backup state and language preference from the old repository-local layout are migrated on first run when possible. Set `WPSF_DATA_ROOT` before launch only if you intentionally need a custom runtime-data location.


### PR DESCRIPTION
Replaces the Unicode box-drawing characters in the README runtime-data tree with plain ASCII. The previous characters were rendered as mojibake in GitHub raw/API output even though the source looked correct locally.

Docs-only change; no application or repair behavior changes.